### PR TITLE
fix: Fix YAML parsing error in Scoop CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -326,8 +326,10 @@ jobs:
           echo "SHA256 windows-arm64: ${SHA_WINDOWS_ARM64}"
 
           # Create updated manifest using jq for proper JSON formatting
+          # Strip "v" prefix for Scoop version field (v1.0.0 -> 1.0.0)
+          SCOOP_VERSION="${VERSION#v}"
           jq -n \
-            --arg version "${VERSION}" \
+            --arg version "${SCOOP_VERSION}" \
             --arg url_amd64 "https://github.com/eannchen/leetsolv/releases/download/${VERSION}/leetsolv-windows-amd64.exe" \
             --arg url_arm64 "https://github.com/eannchen/leetsolv/releases/download/${VERSION}/leetsolv-windows-arm64.exe" \
             --arg hash_amd64 "${SHA_WINDOWS_AMD64}" \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -355,10 +355,10 @@ jobs:
               autoupdate: {
                 architecture: {
                   "64bit": {
-                    url: "https://github.com/eannchen/leetsolv/releases/download/$version/leetsolv-windows-amd64.exe"
+                    url: "https://github.com/eannchen/leetsolv/releases/download/v$version/leetsolv-windows-amd64.exe"
                   },
                   arm64: {
-                    url: "https://github.com/eannchen/leetsolv/releases/download/$version/leetsolv-windows-arm64.exe"
+                    url: "https://github.com/eannchen/leetsolv/releases/download/v$version/leetsolv-windows-arm64.exe"
                   }
                 }
               }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -325,38 +325,42 @@ jobs:
           echo "SHA256 windows-amd64: ${SHA_WINDOWS_AMD64}"
           echo "SHA256 windows-arm64: ${SHA_WINDOWS_ARM64}"
 
-          # Create updated manifest
-          cat > "$MANIFEST" << EOF
-          {
-              "version": "${VERSION}",
-              "description": "A CLI tool for DSA problem revision with spaced repetition, powered by a customized SuperMemo 2 algorithm.",
-              "homepage": "https://github.com/eannchen/leetsolv",
-              "license": "MIT",
-              "architecture": {
-                  "64bit": {
-                      "url": "https://github.com/eannchen/leetsolv/releases/download/${VERSION}/leetsolv-windows-amd64.exe",
-                      "hash": "${SHA_WINDOWS_AMD64}",
-                      "bin": [["leetsolv-windows-amd64.exe", "leetsolv"]]
-                  },
-                  "arm64": {
-                      "url": "https://github.com/eannchen/leetsolv/releases/download/${VERSION}/leetsolv-windows-arm64.exe",
-                      "hash": "${SHA_WINDOWS_ARM64}",
-                      "bin": [["leetsolv-windows-arm64.exe", "leetsolv"]]
-                  }
+          # Create updated manifest using jq for proper JSON formatting
+          jq -n \
+            --arg version "${VERSION}" \
+            --arg url_amd64 "https://github.com/eannchen/leetsolv/releases/download/${VERSION}/leetsolv-windows-amd64.exe" \
+            --arg url_arm64 "https://github.com/eannchen/leetsolv/releases/download/${VERSION}/leetsolv-windows-arm64.exe" \
+            --arg hash_amd64 "${SHA_WINDOWS_AMD64}" \
+            --arg hash_arm64 "${SHA_WINDOWS_ARM64}" \
+            '{
+              version: $version,
+              description: "A CLI tool for DSA problem revision with spaced repetition, powered by a customized SuperMemo 2 algorithm.",
+              homepage: "https://github.com/eannchen/leetsolv",
+              license: "MIT",
+              architecture: {
+                "64bit": {
+                  url: $url_amd64,
+                  hash: $hash_amd64,
+                  bin: [["leetsolv-windows-amd64.exe", "leetsolv"]]
+                },
+                arm64: {
+                  url: $url_arm64,
+                  hash: $hash_arm64,
+                  bin: [["leetsolv-windows-arm64.exe", "leetsolv"]]
+                }
               },
-              "checkver": "github",
-              "autoupdate": {
-                  "architecture": {
-                      "64bit": {
-                          "url": "https://github.com/eannchen/leetsolv/releases/download/\$version/leetsolv-windows-amd64.exe"
-                      },
-                      "arm64": {
-                          "url": "https://github.com/eannchen/leetsolv/releases/download/\$version/leetsolv-windows-arm64.exe"
-                      }
+              checkver: "github",
+              autoupdate: {
+                architecture: {
+                  "64bit": {
+                    url: "https://github.com/eannchen/leetsolv/releases/download/$version/leetsolv-windows-amd64.exe"
+                  },
+                  arm64: {
+                    url: "https://github.com/eannchen/leetsolv/releases/download/$version/leetsolv-windows-arm64.exe"
                   }
+                }
               }
-          }
-          EOF
+            }' > "$MANIFEST"
 
           echo "Updated manifest:"
           cat "$MANIFEST"


### PR DESCRIPTION
## Description
Fix "Flow map in block collection" YAML error by replacing heredoc with jq command for JSON generation.

### Type of Change

- [ ] New feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation update
- [x] Build/CI-related change
- [ ] Other (specify):

## Checklist

- [ ] My code follows the project's style.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] All new and existing unit tests pass locally with my changes.
- [ ] I have manually tested the new functionality in the CLI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved release manifest generation for more consistent, well-formed manifests.
  * Normalized version strings (removes leading "v") so published versions match expected format.
  * Architecture-specific download entries (x64 and arm64) now include explicit URLs, hashes, and binaries.
  * More reliable autoupdate/check-version data to improve installer/update consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->