### PR TITLE
refactor: remove unused mutex locks for single-user CLI

### DIFF
--- a/config/test_utils.go
+++ b/config/test_utils.go
@@ -7,8 +7,9 @@ import (
 
 // MockFileUtil implements FileUtil for testing
 type MockFileUtil struct {
-	loadError error
-	saveError error
+	loadError   error
+	saveError   error
+	deleteError error
 }
 
 func (m *MockFileUtil) Load(data interface{}, filename string) error {
@@ -17,6 +18,10 @@ func (m *MockFileUtil) Load(data interface{}, filename string) error {
 
 func (m *MockFileUtil) Save(data interface{}, filename string) error {
 	return m.saveError
+}
+
+func (m *MockFileUtil) Delete(filename string) error {
+	return m.deleteError
 }
 
 // TestConfig provides a way to override configuration for testing

--- a/internal/fileutil/fileutil.go
+++ b/internal/fileutil/fileutil.go
@@ -14,6 +14,8 @@ type FileUtil interface {
 	// Save writes data to a temporary file and atomically replaces the target file.
 	// This prevents data loss or corruption if the save operation fails or crashes.
 	Save(data interface{}, filename string) error
+	// Delete removes the specified file. Returns nil if file doesn't exist.
+	Delete(filename string) error
 }
 
 type JSONFileUtil struct{}
@@ -78,4 +80,12 @@ func (j *JSONFileUtil) Save(data interface{}, filename string) error {
 		return err
 	}
 	return nil
+}
+
+func (j *JSONFileUtil) Delete(filename string) error {
+	err := os.Remove(filename)
+	if err != nil && os.IsNotExist(err) {
+		return nil // File doesn't exist, nothing to delete
+	}
+	return err
 }

--- a/internal/search/trie.go
+++ b/internal/search/trie.go
@@ -1,8 +1,6 @@
 // Package search implements the trie for the leetsolv application.
 package search
 
-import "sync"
-
 type TrieNode struct {
 	Children   map[rune]*TrieNode
 	IDs        map[int]struct{} // Questions having this prefix
@@ -20,7 +18,6 @@ func NewTrieNode() *TrieNode {
 type Trie struct {
 	Root            *TrieNode
 	MinPrefixLength int
-	mu              sync.RWMutex
 }
 
 func NewTrie(minPrefixLength int) *Trie {
@@ -30,9 +27,6 @@ func NewTrie(minPrefixLength int) *Trie {
 // Hydrate ensures that the trie and all its nodes have their maps initialized.
 // This is useful after deserializing a trie from a source that might be incomplete.
 func (t *Trie) Hydrate() {
-	t.mu.Lock()
-	defer t.mu.Unlock()
-
 	if t.Root == nil {
 		t.Root = NewTrieNode()
 		return
@@ -63,9 +57,6 @@ func hydrateNode(node *TrieNode) {
 }
 
 func (t *Trie) Insert(word string, id int) {
-	t.mu.Lock()
-	defer t.mu.Unlock()
-
 	node := t.Root
 	// Always add ID to root for empty string case
 	node.IDs[id] = struct{}{}
@@ -81,9 +72,6 @@ func (t *Trie) Insert(word string, id int) {
 }
 
 func (t *Trie) SearchPrefix(prefix string) map[int]struct{} {
-	t.mu.RLock()
-	defer t.mu.RUnlock()
-
 	// Special case: empty prefix should return all IDs
 	if prefix == "" {
 		// Return a copy to prevent external modification.
@@ -115,9 +103,6 @@ func (t *Trie) SearchPrefix(prefix string) map[int]struct{} {
 }
 
 func (t *Trie) Delete(word string, id int) {
-	t.mu.Lock()
-	defer t.mu.Unlock()
-
 	// Convert string to a slice of runes once to safely handle Unicode.
 	runes := []rune(word)
 

--- a/usecase/usecase.go
+++ b/usecase/usecase.go
@@ -223,9 +223,6 @@ func (u *QuestionUseCaseImpl) matchesFilter(question core.Question, filter core.
 func (u *QuestionUseCaseImpl) UpsertQuestion(url, note string, familiarity core.Familiarity, importance core.Importance, memory core.MemoryUse) (*core.Delta, error) {
 	u.logger.Info.Printf("Upserting question: URL=%s, Familiarity=%d, Importance=%d", url, familiarity, importance)
 
-	u.Storage.Lock()
-	defer u.Storage.Unlock()
-
 	store, err := u.Storage.LoadQuestionStore()
 	if err != nil {
 		return nil, errs.WrapInternalError(err, "Failed to load question store")
@@ -332,9 +329,6 @@ func (u *QuestionUseCaseImpl) UpsertQuestion(url, note string, familiarity core.
 func (u *QuestionUseCaseImpl) DeleteQuestion(target string) (*core.Question, error) {
 	u.logger.Info.Printf("Deleting question: Target=%s", target)
 
-	u.Storage.Lock()
-	defer u.Storage.Unlock()
-
 	store, err := u.Storage.LoadQuestionStore()
 	if err != nil {
 		return nil, errs.WrapInternalError(err, "Failed to load question store")
@@ -381,9 +375,6 @@ func (u *QuestionUseCaseImpl) DeleteQuestion(target string) (*core.Question, err
 
 func (u *QuestionUseCaseImpl) Undo() error {
 	u.logger.Info.Printf("Undoing last action")
-
-	u.Storage.Lock()
-	defer u.Storage.Unlock()
 
 	deltas, err := u.Storage.LoadDeltas()
 	if err != nil {
@@ -582,9 +573,6 @@ func (u *QuestionUseCaseImpl) UpdateSetting(settingName string, value any) error
 // This is needed for users upgrading from versions that stored local timezone.
 // Returns the number of questions and deltas migrated.
 func (u *QuestionUseCaseImpl) MigrateToUTC() (int, int, error) {
-	u.Storage.Lock()
-	defer u.Storage.Unlock()
-
 	// Migrate questions
 	store, err := u.Storage.LoadQuestionStore()
 	if err != nil {


### PR DESCRIPTION
## Description
1. The locks were added with future server-based architecture in mind, but there are no current plans for multi-user support.
2. Update MOTIVATION.md

### Type of Change

- [ ] New feature
- [ ] Bug fix
- [x] Refactor
- [ ] Documentation update
- [ ] Build/CI-related change
- [ ] Other (specify):

## Checklist

- [x] My code follows the project's style.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] All new and existing unit tests pass locally with my changes.
- [x] I have manually tested the new functionality in the CLI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Streamlined internal storage caching system
  * Updated synchronization model for file operations

* **New Features**
  * Added cache invalidation method for explicit cache control

* **Tests**
  * Improved robustness testing for file and JSON handling

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->