### PR TITLE
Add reset command to delete all user data

### DIFF
--- a/command/command.go
+++ b/command/command.go
@@ -183,3 +183,12 @@ func (c *MigrateCommand) Execute(scanner *bufio.Scanner, args []string) bool {
 	c.Handler.HandleMigrate(scanner)
 	return false
 }
+
+type ResetCommand struct {
+	Handler handler.Handler
+}
+
+func (c *ResetCommand) Execute(scanner *bufio.Scanner, args []string) bool {
+	c.Handler.HandleReset(scanner)
+	return false
+}

--- a/command/command_test.go
+++ b/command/command_test.go
@@ -90,6 +90,10 @@ func (m *MockHandler) HandleMigrate(scanner *bufio.Scanner) {
 	// Not used in command tests
 }
 
+func (m *MockHandler) HandleReset(scanner *bufio.Scanner) {
+	// Not used in command tests
+}
+
 func TestNewCommandRegistry(t *testing.T) {
 	unknownHandler := func(command string) {
 		// This handler is just for testing the constructor

--- a/document/USAGE.md
+++ b/document/USAGE.md
@@ -43,6 +43,7 @@ leetsolv upsert https://leetcode.com/problems/example
 | `undo`    | `back`                | Undo the last action                            |
 | `history` | `hist`, `log`         | Show action history                             |
 | `setting` | `config`, `cfg`       | View and modify application settings            |
+| `reset`   |                       | Delete all questions and history                |
 | `version` | `ver`, `v`            | Show application version information            |
 | `help`    | `h`                   | Show help information                           |
 | `clear`   | `cls`                 | Clear the screen                                |

--- a/handler/handler_test.go
+++ b/handler/handler_test.go
@@ -245,6 +245,13 @@ func (m *MockQuestionUseCase) MigrateToUTC() (int, int, error) {
 	return len(m.questions), 0, nil
 }
 
+func (m *MockQuestionUseCase) ResetData() (int, int, error) {
+	if m.shouldError {
+		return 0, 0, m.errorToReturn
+	}
+	return len(m.questions), 0, nil
+}
+
 // setupTestHandler creates a test handler with mocked dependencies
 func setupTestHandler(t *testing.T) (*HandlerImpl, *MockIOHandler, *MockQuestionUseCase) {
 	_, cfg := config.MockEnv(t)

--- a/main.go
+++ b/main.go
@@ -98,6 +98,9 @@ func main() {
 	migrateCommand := &command.MigrateCommand{Handler: h}
 	commandRegistry.Register("migrate", migrateCommand)
 
+	resetCommand := &command.ResetCommand{Handler: h}
+	commandRegistry.Register("reset", resetCommand)
+
 	clearCommand := &command.ClearCommand{Handler: h}
 	commandRegistry.Register("clear", clearCommand)
 	commandRegistry.Register("cls", clearCommand)

--- a/storage/file.go
+++ b/storage/file.go
@@ -12,6 +12,7 @@ type Storage interface {
 	SaveQuestionStore(*QuestionStore) error
 	LoadDeltas() ([]core.Delta, error)
 	SaveDeltas([]core.Delta) error
+	DeleteAllData() error
 }
 
 func NewFileStorage(questionsFileName, deltasFileName string, file fileutil.FileUtil) *FileStorage {
@@ -122,4 +123,23 @@ func (fs *FileStorage) SaveDeltas(deltas []core.Delta) error {
 func (fs *FileStorage) InvalidateCache() {
 	fs.questionStoreCache = nil
 	fs.deltasCache = nil
+}
+
+// DeleteAllData deletes both questions and deltas files, and invalidates cache
+func (fs *FileStorage) DeleteAllData() error {
+	// Delete questions file
+	if err := fs.file.Delete(fs.questionsFileName); err != nil {
+		return err
+	}
+
+	// Delete deltas file
+	if err := fs.file.Delete(fs.deltasFileName); err != nil {
+		return err
+	}
+
+	// Invalidate cache
+	fs.questionStoreCache = nil
+	fs.deltasCache = nil
+
+	return nil
 }


### PR DESCRIPTION
### Type of Change
Add a `reset` command that allows users to delete all their questions and undo history without manually locating the data files.

- [x] New feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation update
- [ ] Build/CI-related change
- [ ] Other (specify):

## Checklist

- [x] My code follows the project's style.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] All new and existing unit tests pass locally with my changes.
- [x] I have manually tested the new functionality in the CLI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a reset command that allows users to delete all questions and history records. Requires confirmation before deletion and displays the count of deleted items.

* **Documentation**
  * Updated usage documentation to include the new reset command and its functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->